### PR TITLE
RestClient update ~> 2.x

### DIFF
--- a/tire.gemspec
+++ b/tire.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   # = Library dependencies
   #
   s.add_dependency "rake"
-  s.add_dependency "rest-client", "~> 1.6"
+  s.add_dependency "rest-client", "~> 2.0"
   s.add_dependency "multi_json",  "~> 1.3"
   s.add_dependency "activemodel", ">= 3.0"
   s.add_dependency "hashr",       "~> 0.0.19"

--- a/tire.gemspec
+++ b/tire.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   # = Library dependencies
   #
   s.add_dependency "rake"
-  s.add_dependency "rest-client", "~> 2.0"
+  s.add_dependency "rest-client", ">= 1.6"
   s.add_dependency "multi_json",  "~> 1.3"
   s.add_dependency "activemodel", ">= 3.0"
   s.add_dependency "hashr",       "~> 0.0.19"


### PR DESCRIPTION
### Description

* `tire` is blocking the RFE upgrade due to locking `rest-client` to 1.6. v2 doesn't seem to have any significant changes, so updating this restriction seems safe

